### PR TITLE
Use secrets for OpenAI API key

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,14 +5,13 @@ from openai import OpenAI
 st.title("💬 Chatbot")
 st.write(
     "This is a simple chatbot that uses OpenAI's GPT-3.5 model to generate responses. "
-    "To use this app, you need to provide an OpenAI API key, which you can get [here](https://platform.openai.com/account/api-keys). "
+    "The app expects an OpenAI API key configured in its secrets. "
     "You can also learn how to build this app step by step by [following our tutorial](https://docs.streamlit.io/develop/tutorials/llms/build-conversational-apps)."
 )
 
-# Ask user for their OpenAI API key via `st.text_input`.
-# Alternatively, you can store the API key in `./.streamlit/secrets.toml` and access it
-# via `st.secrets`, see https://docs.streamlit.io/develop/concepts/connections/secrets-management
-openai_api_key = st.text_input("OpenAI API Key", type="password")
+# Retrieve the OpenAI API key from Streamlit secrets. Update `.streamlit/secrets.toml`
+# to set the `openai_api_key` value.
+openai_api_key = st.secrets.get("openai_api_key")
 if not openai_api_key:
     st.info("Please add your OpenAI API key to continue.", icon="🗝️")
 else:


### PR DESCRIPTION
## Summary
- load OpenAI API key from Streamlit secrets instead of prompting the user
- update description to note that the key is stored in secrets

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab90fc1c348320ac6e81c6c61789cb